### PR TITLE
Add historical player data to Steam game search:

### DIFF
--- a/src/commands/information.py
+++ b/src/commands/information.py
@@ -238,10 +238,27 @@ class InformationCommands(BaseCommands):
             color=discord.Color.blue()
         )
         
-        if player_count is not None and player_count > 0:
-            embed.add_field(name="현재 플레이어 수", value=f"{player_count:,}명")
-        else:
-            embed.add_field(name="현재 플레이어 수", value="정보 없음")
+        # Get current and historical player data
+        try:
+            if player_count is not None and player_count > 0:
+                embed.add_field(name="현재 플레이어", value=f"{player_count:,}명", inline=True)
+                
+                # Get historical data
+                history = await self.api.get_player_history(game['appid'])
+                if history:
+                    trend = "📈" if history['trend'] > 0 else "📉"
+                    embed.add_field(
+                        name="7일 최고/평균", 
+                        value=f"최고: {history['peak_7d']:,}명\n"
+                              f"평균: {history['avg_7d']:,}명\n"
+                              f"추세: {trend}",
+                        inline=True
+                    )
+            else:
+                embed.add_field(name="현재 플레이어", value="정보 없음", inline=True)
+        except Exception as e:
+            logger.error(f"Error getting player history: {e}")
+            embed.add_field(name="플레이어 정보", value="데이터를 가져오는데 실패했습니다", inline=True)
         
         if similarity < 100:
             embed.add_field(

--- a/src/services/api.py
+++ b/src/services/api.py
@@ -461,4 +461,29 @@ class APIService:
             
         except Exception as e:
             logger.error(f"Error getting exchange rates: {e}")
-            raise APIError(f"Failed to get exchange rates: {str(e)}") 
+            raise APIError(f"Failed to get exchange rates: {str(e)}")
+
+    async def get_player_history(self, app_id: int) -> Dict:
+        """Get historical player data for a game"""
+        try:
+            url = f"https://steamcharts.com/app/{app_id}/chart-data.json"
+            data = await self._get_with_retry(url, endpoint='steam_charts')
+            
+            if not data:
+                return None
+            
+            # Get last 7 days of data
+            recent_data = data[-7:]
+            
+            # Calculate peak and average
+            peak_players = max(point[1] for point in recent_data)
+            avg_players = sum(point[1] for point in recent_data) // len(recent_data)
+            
+            return {
+                'peak_7d': peak_players,
+                'avg_7d': avg_players,
+                'trend': recent_data[-1][1] - recent_data[0][1]  # Positive means growing
+            }
+        except Exception as e:
+            logger.error(f"Error getting player history for {app_id}: {e}")
+            return None 


### PR DESCRIPTION
- Add get_player_history method to APIService
- Show 7-day peak and average player counts
- Add player count trend indicator (📈/📉)
- Improve player count display formatting
- Add error handling for historical data fetching