### PR TITLE
feat: add game preview images and fix import paths - Add game preview…

### DIFF
--- a/src/commands/information.py
+++ b/src/commands/information.py
@@ -257,6 +257,10 @@ class InformationCommands(BaseCommands):
             embed.add_field(name="7일 최고", value=f"{game['peak_7d']:,}명", inline=True)
             embed.add_field(name="7일 평균", value=f"{game['avg_7d']:,.1f}명", inline=True)
 
+        # Add game image if available
+        if game.get("image_url"):
+            embed.set_thumbnail(url=game["image_url"])
+
         return embed
 
     async def _send_steam_error_embed(self, ctx_or_interaction, user_name: str):

--- a/src/main.py
+++ b/src/main.py
@@ -5,10 +5,10 @@ import os
 from typing import NoReturn, Dict
 
 import discord
-from api_service import APIService
+from src.services.api_service import APIService
 
 from src.bot import DiscordBot
-from commands import EntertainmentCommands, InformationCommands, SystemCommands
+from src.commands import EntertainmentCommands, InformationCommands, SystemCommands
 
 logger = logging.getLogger(__name__)
 

--- a/src/services/api/steam.py
+++ b/src/services/api/steam.py
@@ -94,7 +94,8 @@ class SteamAPI(BaseAPI[GameInfo]):
                         peak_24h=history["peak_24h"],
                         peak_7d=history["peak_7d"],
                         avg_7d=history["avg_7d"],
-                        history=history.get("history")
+                        history=history.get("history"),
+                        image_url=item.get("tiny_image") or item.get("large_capsule_image")
                     )
                     games.append(game_info)
                 except Exception as e:

--- a/src/utils/api_types.py
+++ b/src/utils/api_types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, List, Dict, Any, Optional
+from typing import TypedDict, List, Dict, Any, Optional, Tuple
 
 class GameInfo(TypedDict):
     name: str
@@ -6,6 +6,8 @@ class GameInfo(TypedDict):
     peak_24h: int
     peak_7d: int
     avg_7d: float
+    image_url: Optional[str]
+    history: Optional[List[Tuple[float, int]]]
 
 class CountryInfo(TypedDict):
     name: Dict[str, str]


### PR DESCRIPTION
… images to Steam command responses - Fix import paths in main.py to use full module paths (src.services.api_service, src.commands)