### PR TITLE
Force hot reload - add version marker to team draft logging

### DIFF
--- a/src/commands/team_draft.py
+++ b/src/commands/team_draft.py
@@ -152,7 +152,7 @@ class TeamDraftCommands(BaseCommands):
         test_mode: bool = False
     ) -> None:
         """Start a new draft session"""
-        logger.info(f"페어 command called by {interaction.user.name} with test_mode={test_mode}")
+        logger.info(f"페어 command called by {interaction.user.name} with test_mode={test_mode} (v2)")
         try:
             await self._handle_draft_start(interaction, players, test_mode)
         except Exception as e:


### PR DESCRIPTION
- Add (v2) to draft start log message to trigger deployment refresh
- This should ensure our bot instance fixes are properly deployed
- Addressing line 134 error that suggests old cached code is still running