### PR TITLE
Add manual cleanup commands and audit logging to team draft system

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -28,7 +28,7 @@ from src.services.api.service import APIService
 
 logger = logging.getLogger(__name__)
 
-# Help description for the bot V15
+# Help description for the bot V16
 HELP_DESCRIPTION = """
 **주요 명령어**:
 • `/chat` - AI와 대화하기


### PR DESCRIPTION
- Add hidden admin commands for manual draft cleanup (뮤 페어정리/페어정리)
- Add comprehensive audit logging system with timestamps and user tracking
- Add audit log viewing command (뮤 페어로그/페어로그)
- Update 6v6 draft pattern from 1-2,2-2,1-1,1-0 to 1-2,2-2,2-1
- Commands are hidden from regular users using permission checks
- Minimal code changes to existing functionality